### PR TITLE
Dynmap version changed to 3.1-beta-1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ aop = 1.0
 javax_inject = 1
 
 # Dynmap
-dynmap_version = 3.0-beta-10
+dynmap_version = 3.1-beta-1
 
 # Annotations
 checker_qual=3.0.1


### PR DESCRIPTION
DynmapCore-3.0-beta-10 isn't hosted anymore, updated DynmapCore to the latest beta version.