### PR TITLE
Fix TranslatedText translate default behavior

### DIFF
--- a/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/util/TranslatedText.kt
+++ b/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/util/TranslatedText.kt
@@ -34,7 +34,7 @@ class TranslatedText(val key: String, vararg val args: Any?) {
      */
     fun translate(languageCode: String): String {
         val langMap = GunpowderMod.instance.languageEngine.get(languageCode)
-        return langMap.getOrDefault(key, key).format(*args)
+        return langMap.getOrDefault(key, GunpowderMod.instance.languageEngine.get("en_us").getOrDefault(key, key)).format(*args)
     }
 
     /**


### PR DESCRIPTION
TranslatedText translate used to just returns key if not present if map of/ given language code.
Now it attempts to look for the key with default language code of en_us, returns key if that also fails.