### PR TITLE
Make ChestGui.Builder extend ChestGui.Container

### DIFF
--- a/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
+++ b/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
@@ -75,6 +75,9 @@ interface ChestGui {
     }
 
     interface Container {
+        /**
+         * Remove all buttons from this gui.
+         */
         fun clearButtons()
 
         /**
@@ -87,6 +90,7 @@ interface ChestGui {
          */
         fun button(x: Int, y: Int, icon: ItemStack, clickCallback: BiConsumer<SlotActionType, Container>) = button(x, y, icon, clickCallback::accept)
         fun button(x: Int, y: Int, icon: ItemStack, clickCallback: (SlotActionType, Container) -> Unit)
+
         /**
          * The default itemstack for unspecified buttons. ItemStack.EMPTY by default.
          */

--- a/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
+++ b/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
@@ -52,27 +52,11 @@ interface ChestGui {
         }
     }
 
-    interface Builder {
+    interface Builder: Container {
         /**
          * Set the player to sync the GUI with.
          */
         fun player(player: ServerPlayerEntity)
-
-        /**
-         * Add an item as button.
-         *
-         * @param x the column in the chest
-         * @param y the row in the chest
-         * @param icon the ItemStack to display
-         * @param clickCallback the callback to execute when clicked
-         */
-        fun button(x: Int, y: Int, icon: ItemStack, clickCallback: BiConsumer<SlotActionType, Container>) = button(x, y, icon, clickCallback::accept)
-        fun button(x: Int, y: Int, icon: ItemStack, clickCallback: (SlotActionType, Container) -> Unit)
-
-        /**
-         * The default itemstack for unspecified buttons. ItemStack.EMPTY by default.
-         */
-        fun emptyIcon(icon: ItemStack)
 
         /**
          * Time in seconds between sending contents. 0 to disable
@@ -92,8 +76,20 @@ interface ChestGui {
 
     interface Container {
         fun clearButtons()
+
+        /**
+         * Add an item as button.
+         *
+         * @param x the column in the chest
+         * @param y the row in the chest
+         * @param icon the ItemStack to display
+         * @param clickCallback the callback to execute when clicked
+         */
         fun button(x: Int, y: Int, icon: ItemStack, clickCallback: BiConsumer<SlotActionType, Container>) = button(x, y, icon, clickCallback::accept)
         fun button(x: Int, y: Int, icon: ItemStack, clickCallback: (SlotActionType, Container) -> Unit)
+        /**
+         * The default itemstack for unspecified buttons. ItemStack.EMPTY by default.
+         */
         fun emptyIcon(icon: ItemStack)
     }
 }

--- a/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/builders/ChestGui.kt
+++ b/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/builders/ChestGui.kt
@@ -78,6 +78,10 @@ object ChestGui : APIChestGui {
             this.size = rows
         }
 
+        override fun clearButtons() {
+            buttons.clear()
+        }
+
         override fun build(syncId: Int): ScreenHandler {
             val type = when (size) {
                 1 -> ScreenHandlerType.GENERIC_9X1
@@ -95,6 +99,5 @@ object ChestGui : APIChestGui {
                 createInventory()
             }
         }
-
     }
 }


### PR DESCRIPTION
Currently, if you want to have back buttons in your chestgui, the first page must have duplicated code:
```kt
class MyGui {
    fun screen(): ChestGui.Container.() -> Unit =  {
        clearButtons()
        categories.forEachIndexed { i, page ->
            button(i, 0, page.icon.stack.setCustomName(LiteralText(page.name))) { _, container -> page.screen(::screen)(container) }
        }
    }

    fun gui(player: ServerPlayerEntity): NamedScreenHandlerFactory {
        val gui = ChestGui.factory {
            player(player)

            categories.forEachIndexed { i, category ->
                button(
                    i,
                    0,
                    category.icon.stack.setCustomName(LiteralText(category.name))
                ) { _, container -> category.screen(::screen)(container) }
			}
		}

		//[...whatever else...]
	}
}
```

```kt
class MySubGui {
    fun screen(previous: (() -> ChestGui.Container.() -> Unit)? = null): ChestGui.Container.() -> Unit = {
        clearButtons()
        //[...whatever gui code...]

        if (previous != null) {
            button(8, 5, Items.FEATHER.defaultStack.setCustomName(LiteralText("Back"))) { _, container -> previous()(container) }
        }
    }
}
```

If, however, `ChestGui.Builder` extends `ChestGui.Container`, the first class becomes much simplified:
```kt
class MyGui {
    fun screen(): ChestGui.Container.() -> Unit =  {
        clearButtons()
        categories.forEachIndexed { i, page ->
            button(i, 0, page.icon.stack.setCustomName(LiteralText(page.name))) { _, container -> page.screen(::screen)(container) }
        }
    }

    fun gui(player: ServerPlayerEntity): NamedScreenHandlerFactory {
        val gui = ChestGui.factory {
            player(player)
			screen()()
		}
		//[...whatever else...]
	}
}
```