### PR TITLE
Add close and getPlayer methods to `ChestGui.Container`

### DIFF
--- a/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
+++ b/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
@@ -100,6 +100,11 @@ interface ChestGui {
         fun emptyIcon(icon: ItemStack)
 
         /**
+         * Get the player viewing this gui, or else null.
+         */
+        fun getPlayer(): ServerPlayerEntity?
+
+        /**
          * Close the gui.
          */
         fun close()

--- a/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
+++ b/gunpowder-api/src/main/kotlin/io/github/gunpowder/api/builders/ChestGui.kt
@@ -70,6 +70,9 @@ interface ChestGui {
          */
         fun size(rows: Int)
 
+        @Deprecated("Not supported for builder.", ReplaceWith(""))
+        override fun close() = throw UnsupportedOperationException("Cannot close unbuilt ChestGUI")
+
         @Deprecated("Used internally, do not use.")
         fun build(syncId: Int): ScreenHandler
     }
@@ -95,5 +98,10 @@ interface ChestGui {
          * The default itemstack for unspecified buttons. ItemStack.EMPTY by default.
          */
         fun emptyIcon(icon: ItemStack)
+
+        /**
+         * Close the gui.
+         */
+        fun close()
     }
 }

--- a/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/builders/ChestGui.kt
+++ b/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/builders/ChestGui.kt
@@ -41,7 +41,7 @@ object ChestGui : APIChestGui {
 
         private val buttons = mutableMapOf<Int, ChestGuiButton>()
         private var icon: ItemStack = ItemStack.EMPTY
-        private var player: PlayerEntity? = null
+        private var player: ServerPlayerEntity? = null
         private var refreshInterval: Int = 0
         private var size: Int = 6
         private var callback = { c: APIChestGui.Container ->}
@@ -49,6 +49,8 @@ object ChestGui : APIChestGui {
         override fun player(player: ServerPlayerEntity) {
             this.player = player
         }
+
+        override fun getPlayer(): ServerPlayerEntity? = this.player
 
         override fun button(x: Int, y: Int, icon: ItemStack, clickCallback: (SlotActionType, APIChestGui.Container) -> Unit) {
             if (x < 0 || x > 8) {

--- a/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/mc/ChestGuiContainer.kt
+++ b/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/mc/ChestGuiContainer.kt
@@ -42,7 +42,7 @@ import net.minecraft.server.network.ServerPlayerEntity
 class ChestGuiContainer(type: ScreenHandlerType<GenericContainerScreenHandler>,
                         syncId: Int, playerInventory: PlayerInventory, rows: Int) :
         GenericContainerScreenHandler(type, syncId, playerInventory, SimpleInventory(9 * rows), rows), APIChestGui.Container {
-    private val player: PlayerEntity = playerInventory.player
+    private val player: ServerPlayerEntity = playerInventory.player as ServerPlayerEntity
 
     private var buttons: MutableMap<Int, ChestGui.Builder.ChestGuiButton> = mutableMapOf()
     private var background = ItemStack.EMPTY
@@ -133,6 +133,8 @@ class ChestGuiContainer(type: ScreenHandlerType<GenericContainerScreenHandler>,
     override fun emptyIcon(icon: ItemStack) {
         setBackground(icon)
     }
+
+    override fun getPlayer(): ServerPlayerEntity? = player
 
     override fun close() {
         syncInventory(player)

--- a/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/mc/ChestGuiContainer.kt
+++ b/gunpowder-base/src/main/kotlin/io/github/gunpowder/entities/mc/ChestGuiContainer.kt
@@ -42,6 +42,8 @@ import net.minecraft.server.network.ServerPlayerEntity
 class ChestGuiContainer(type: ScreenHandlerType<GenericContainerScreenHandler>,
                         syncId: Int, playerInventory: PlayerInventory, rows: Int) :
         GenericContainerScreenHandler(type, syncId, playerInventory, SimpleInventory(9 * rows), rows), APIChestGui.Container {
+    private val player: PlayerEntity = playerInventory.player
+
     private var buttons: MutableMap<Int, ChestGui.Builder.ChestGuiButton> = mutableMapOf()
     private var background = ItemStack.EMPTY
     private var interval = 0
@@ -65,6 +67,12 @@ class ChestGuiContainer(type: ScreenHandlerType<GenericContainerScreenHandler>,
         for (i in 0 until 54) {
             inventory.setStack(i, buttons[i]?.icon ?: background)
         }
+    }
+
+    private fun syncInventory(playerEntity: PlayerEntity) {
+        inventory.markDirty()
+        (playerEntity as ServerPlayerEntity).server.playerManager.sendToAll(InventoryS2CPacket(syncId, playerEntity.currentScreenHandler.stacks))
+        sendContentUpdates()
     }
 
     override fun canUse(player: PlayerEntity?): Boolean {
@@ -96,10 +104,7 @@ class ChestGuiContainer(type: ScreenHandlerType<GenericContainerScreenHandler>,
             button.callback.invoke(actionType, this)
         }
 
-        // Avoid desyncs
-        inventory.markDirty()
-        (playerEntity as ServerPlayerEntity).server.playerManager.sendToAll(InventoryS2CPacket(syncId, playerEntity.currentScreenHandler.stacks))
-        sendContentUpdates()
+        syncInventory(playerEntity)
 
         return ItemStack.EMPTY
     }
@@ -127,5 +132,10 @@ class ChestGuiContainer(type: ScreenHandlerType<GenericContainerScreenHandler>,
 
     override fun emptyIcon(icon: ItemStack) {
         setBackground(icon)
+    }
+
+    override fun close() {
+        syncInventory(player)
+        close(player)
     }
 }


### PR DESCRIPTION
This closes #104 by providing a way to close ChestGuis from a button press without causing potential desyncs.

It also provides a way for chestguis to access the current player, e.g. to give items to the player on button press.